### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.trash-cache
 /.vscode
 debug
+alerting-client

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,7 +20,7 @@ ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 
-ENV DAPPER_SOURCE /go/src/github.com/rancher/alerting-agent/
+ENV DAPPER_SOURCE /go/src/github.com/rancher/alerting-client/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
 ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-alerting-agent
+alerting-client
 ========
 
 A microservice that does micro things.
@@ -10,10 +10,10 @@ A microservice that does micro things.
 
 ## Running
 
-`./bin/alerting-agent`
+`./bin/alerting-client`
 
 ## License
-Copyright (c) 2014-2016 [Rancher Labs, Inc.](http://rancher.com)
+Copyright (c) 2014-2017 [Rancher Labs, Inc.](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/alert/alert.go
+++ b/alert/alert.go
@@ -1,0 +1,21 @@
+package alert
+
+import (
+	"os"
+)
+
+type Alert struct {
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	SourceHostname string `json:"host"`
+}
+
+func New(name, description string) *Alert {
+	hostname, _ := os.Hostname()
+
+	return &Alert{
+		Name:           name,
+		Description:    description,
+		SourceHostname: hostname,
+	}
+}

--- a/alert/sender.go
+++ b/alert/sender.go
@@ -1,0 +1,84 @@
+package alert
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+type AlertSender struct {
+	alertEndpoint string
+	alerts        chan *Alert
+	httpClient    http.Client
+	log           *log.Entry
+}
+
+func NewSender(alertAddress string, bufferSize int) *AlertSender {
+	s := &AlertSender{
+		alertEndpoint: fmt.Sprintf("http://%s/report_alert", alertAddress),
+		alerts:        make(chan *Alert, bufferSize),
+		httpClient: http.Client{
+			Timeout: 2 * time.Second,
+		},
+		log: log.WithField("pkg", "alert_sender"),
+	}
+	go s.watch()
+	return s
+}
+
+func (s *AlertSender) Send(a *Alert) {
+	s.alerts <- a
+}
+
+func (s *AlertSender) watch() {
+	for a := range s.alerts {
+		l := s.log.WithField("name", a.Name)
+		l.Debug("Received alert")
+
+		if err := s.send(a); err != nil {
+			l.WithField("error", err.Error()).Error("Could not send alert")
+		}
+
+		l.Debugf("Chan alerts at %d%% capacity (%d/%d)",
+			len(s.alerts)*100/cap(s.alerts), len(s.alerts), cap(s.alerts))
+	}
+}
+
+func (s *AlertSender) send(a *Alert) error {
+	data, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+
+	var req *http.Request
+	req, err = http.NewRequest("POST", s.alertEndpoint, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/plain")
+	req.Header.Set("Content-Type", "application/json")
+
+	var resp *http.Response
+	resp, err = s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return errors.New(fmt.Sprintf("Server return HTTP %d", resp.StatusCode))
+	}
+
+	if log.GetLevel() == log.DebugLevel {
+		s.log.Debugf("response Status: %s", resp.Status)
+		s.log.Debugf("response Headers: %v", resp.Header)
+		body, _ := ioutil.ReadAll(resp.Body)
+		s.log.Debugf("response Body: %s", string(body))
+	}
+	return nil
+}

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/Sirupsen/logrus"
-
 	"github.com/gorilla/mux"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,70 +1,61 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
-	"github.com/urfave/cli"
-
 	"os"
+	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/chrisurwin/alerting-client/agent"
+	"github.com/urfave/cli"
 )
 
 var VERSION = "v0.1.0-dev"
 
 func beforeApp(c *cli.Context) error {
 	if c.GlobalBool("debug") {
-		logrus.SetLevel(logrus.DebugLevel)
+		log.SetLevel(log.DebugLevel)
 	}
 	return nil
 }
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "alerting-agent"
+	app.Name = "alerting-client"
 	app.Version = VERSION
 	app.Usage = "Container to monitor Rancher Infrastructure Services"
 	app.Action = start
 	app.Before = beforeApp
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
-			Name:  "debug,d",
-			Usage: "Debug logging",
+			Name:   "debug,d",
+			Usage:  "Debug logging",
+			EnvVar: "DEBUG",
 		},
-		cli.StringFlag{
-			Name:   "poll-interval",
-			Value:  "30",
-			Usage:  "Polling interval for check",
+		cli.DurationFlag{
+			Name:   "poll-interval,i",
+			Value:  30 * time.Second,
+			Usage:  "Polling interval for checks",
 			EnvVar: "POLL_INTERVAL",
 		},
 		cli.StringFlag{
-			Name:   "server-hostname",
-			Usage:  "Alerting server",
-			Value:  "localhost",
-			EnvVar: "SERVER_HOSTNAME",
+			Name:   "alert-address,a",
+			Usage:  "Alerting server address",
+			Value:  "localhost:5050",
+			EnvVar: "SERVER_ADDRESS",
 		},
-		cli.StringFlag{
-			Name:   "server-port",
-			Value:  "5050",
-			Usage:  "Alerting server port",
-			EnvVar: "SERVER_PORT",
-		},
-		cli.StringFlag{
-			Name:   "k8s",
-			Value:  "false",
+		cli.BoolFlag{
+			Name:   "k8s,k",
 			Usage:  "Specify if environment is a kubernetes environment",
 			EnvVar: "K8S",
 		},
 	}
 	app.Run(os.Args)
-
 }
 
 func start(c *cli.Context) {
-
-	if c.GlobalString("server-hostname") == "" {
-		logrus.Fatalf("SERVER_HOSTNAME not set")
+	if c.String("alert-address") == "" {
+		log.Fatal("Alerting server address not set")
 	}
-	for {
-		agent.StartAgent(c.GlobalString("server-hostname"), c.GlobalString("server-port"), c.GlobalString("poll-interval"), c.GlobalString("k8s"))
-	}
+	a := agent.NewAgent(c.String("alert-address"), c.Duration("poll-interval"), c.Bool("k8s"))
+	a.Start()
 }

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine:3.6
-COPY alerting-agent /usr/bin/
-CMD ["alerting-agent"]
+COPY alerting-client /usr/bin/
+CMD ["alerting-client"]

--- a/scripts/build
+++ b/scripts/build
@@ -7,4 +7,4 @@ cd $(dirname $0)/..
 
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/alerting-agent
+CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/alerting-client

--- a/scripts/package
+++ b/scripts/package
@@ -12,9 +12,9 @@ cd $(dirname $0)/../package
 TAG=${TAG:-${VERSION}${SUFFIX}}
 REPO=${REPO:-rancher}
 
-cp ../bin/alerting-agent .
+cp ../bin/alerting-client .
 
-IMAGE=${REPO}/alerting-agent:${TAG}
+IMAGE=${REPO}/alerting-client:${TAG}
 docker build -t ${IMAGE} .
 echo ${IMAGE} > ../dist/images
 echo Built ${IMAGE}

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 # package
-github.com/rancher/alerting-agent
+github.com/rancher/alerting-client
 
-github.com/Sirupsen/logrus        v0.10.0
-github.com/urfave/cli             v1.18.0
+github.com/Sirupsen/logrus        v1.0.1
+github.com/urfave/cli             v1.19.1


### PR DESCRIPTION
* Use ticker for main check/probe loop
* Perform probes concurrently, wait to complete using WaitGroup
* Construct DNS/HTTP clients once, store in appropriate structs
* Relax HTTP probe to accept 2XX Responses
* Decouple detection and transmission of alerts, use a buffered channel for alerts
* Use latest and greatest vendor dependencies
* Rename all paths from `alerting-agent` to `alerting-client` for consistency
* Enhance logging
* Go formatting
